### PR TITLE
Fix light theme text visibility

### DIFF
--- a/css/components/header.css
+++ b/css/components/header.css
@@ -114,7 +114,7 @@ input:checked + .theme-toggle:after {
 
 /* Icon + text visibility */
 .nav-item i {
-    color: #ffffff;
+    color: var(--primary-color);
     margin-right: 0; font-size: 1.2rem;
 }
 
@@ -129,7 +129,7 @@ input:checked + .theme-toggle:after {
     }
 }
 .nav-link .fa-circle-user {
-    color: #ffffff !important;
+    color: var(--primary-color) !important;
 }
 
 @media (max-width: 768px) {

--- a/css/main.css
+++ b/css/main.css
@@ -21,6 +21,7 @@
     --header-bg-dark: rgba(30, 30, 30, 0.85);
     --footer-bg-dark: rgba(18, 18, 18, 0.9);
     --border-dark: rgba(255, 255, 255, 0.1);
+    --text-color: #ffffff;
 }
 
 body, input, textarea, button, select, optgroup {
@@ -37,7 +38,7 @@ body, input, textarea, button, select, optgroup {
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    color: #ffffff; /* Fixed white text */
+    color: var(--text-color); /* Theme-based text color */
     background-color: var(--bg-color);
     transition: color 0.3s ease;
 }
@@ -51,7 +52,7 @@ h1, h2, h3, h4, h5, h6 {
             monospace;
     font-weight: 700;
     letter-spacing: -0.5px;
-    color: #ffffff; /* Fixed white text */
+    color: var(--text-color); /* Theme-based text color */
     transition: color 0.3s ease;
 }
 
@@ -67,7 +68,7 @@ pre, code, kbd, samp {
     background-color: rgba(0,0,0,0.05);
     border-radius: 4px;
     padding: 0.2em 0.4em;
-    color: #ffffff; /* Fixed white text */
+    color: var(--text-color); /* Theme-based text color */
     transition: color 0.3s ease;
 }
 
@@ -91,19 +92,19 @@ pre {
     padding: 0.1em 0.3em;
     border-radius: 3px;
     margin: 0 0.2em;
-    color: #ffffff; /* Fixed white text */
+    color: var(--text-color); /* Theme-based text color */
     transition: color 0.3s ease;
 }
 
 /* Add styles for regular text */
 p, span, div, a:not(.btn), label, li {
-    color: #ffffff; /* Fixed white text */
+    color: var(--text-color); /* Theme-based text color */
     transition: color 0.3s ease;
 }
 
 /* Add styles for form elements */
 .form-control, .form-control:focus {
-    color: #ffffff; /* Fixed white text */
+    color: var(--text-color); /* Theme-based text color */
     background-color: var(--card-bg);
     border-color: var(--border-color);
     transition: color 0.3s ease, background-color 0.3s ease;

--- a/css/themes/light-theme.css
+++ b/css/themes/light-theme.css
@@ -3,7 +3,7 @@ body[data-theme="light"] {
     --primary-color: var(--primary-color-light);
     --secondary-color: var(--secondary-color-light);
     --bg-color: var(--bg-light);
-    --text-color: #ffffff; /* Forced to white */
+    --text-color: #111111; /* Dark text for light theme */
     --card-bg: var(--card-bg-light);
     --header-bg: var(--header-bg-light);
     --footer-bg: rgba(255, 255, 255, 0.5);


### PR DESCRIPTION
## Summary
- ensure dark text is used in light theme
- rely on CSS variable for all text colors
- align header icon colors with active theme

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870b8178f38832484d088ac6f400dda