### PR TITLE
Fix card text contrast

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -21,7 +21,8 @@
     --header-bg-dark: rgba(30, 30, 30, 0.85);
     --footer-bg-dark: rgba(18, 18, 18, 0.9);
     --border-dark: rgba(255, 255, 255, 0.1);
-    --text-color: #ffffff;
+    --text-color: #111111;
+    --card-bg: var(--card-bg-light);
 }
 
 body, input, textarea, button, select, optgroup {


### PR DESCRIPTION
## Summary
- set default text color to black
- set a default value for `--card-bg`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870bb351db0832485c29913d9bc4fd1