### PR TITLE
Fix dark-mode skill card visibility

### DIFF
--- a/css/themes/dark-theme.css
+++ b/css/themes/dark-theme.css
@@ -34,6 +34,12 @@ body[data-theme="dark"] .portfolio-content p {
     color: #ffffff !important;
 }
 
+/* Ensure skill cards have a dark background and white text */
+body[data-theme="dark"] .skill-card {
+    background-color: var(--card-bg-dark);
+    color: #ffffff;
+}
+
 /* Animation for dark theme transition */
 @keyframes lightToDark {
     0% { opacity: 0.8; }

--- a/css/themes/light-theme.css
+++ b/css/themes/light-theme.css
@@ -17,3 +17,9 @@ body[data-theme="light"] {
     --bg-opacity: 0.04;
     --overlay-opacity: 0.02;
 }
+
+/* Ensure skill cards are readable in light theme */
+body[data-theme="light"] .skill-card {
+    background-color: var(--card-bg-light);
+    color: #111111;
+}


### PR DESCRIPTION
## Summary
- ensure skill cards adapt to theme colors

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6870bd9338d48324b2b418dfd5ce8fa5