### PR TITLE
Make cards glossy and theme independent

### DIFF
--- a/css/components/portfolio.css
+++ b/css/components/portfolio.css
@@ -121,8 +121,10 @@
 /* Blog card styling */
 .card {
     background-color: var(--card-bg);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    border: 1px solid rgba(255, 255, 255, 0.1);
     transition: transform 0.3s ease, box-shadow 0.3s ease;
-    border: none;
     border-radius: 0.5rem;
     overflow: hidden;
     box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);

--- a/css/components/skills.css
+++ b/css/components/skills.css
@@ -12,7 +12,9 @@
 
 .skill-card {
     background-color: var(--card-bg);
-    border: 1px solid var(--border-color);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    border: 1px solid rgba(255, 255, 255, 0.1);
     border-radius: 0.5rem;
     padding: 1.5rem;
     height: 100%;

--- a/css/main.css
+++ b/css/main.css
@@ -7,7 +7,6 @@
     --secondary-color-light: #3498db;
     --bg-light: #f8f9fa;
     --text-light: #ffffff; /* unused now */
-    --card-bg-light: #ffffff;
     --header-bg-light: rgba(255, 255, 255, 0.85);
     --footer-bg-light: #ffffff;
     --border-light: rgb(255, 255, 255);
@@ -17,12 +16,11 @@
     --secondary-color-dark: #03dac6;
     --bg-dark: #121212;
     --text-dark: #ffffff; /* unused now */
-    --card-bg-dark: rgba(30, 30, 30, 0.85);
     --header-bg-dark: rgba(30, 30, 30, 0.85);
     --footer-bg-dark: rgba(18, 18, 18, 0.9);
     --border-dark: rgba(255, 255, 255, 0.1);
     --text-color: #111111;
-    --card-bg: var(--card-bg-light);
+    --card-bg: rgba(255, 255, 255, 0.15);
 }
 
 body, input, textarea, button, select, optgroup {
@@ -107,6 +105,8 @@ p, span, div, a:not(.btn), label, li {
 .form-control, .form-control:focus {
     color: var(--text-color); /* Theme-based text color */
     background-color: var(--card-bg);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
     border-color: var(--border-color);
     transition: color 0.3s ease, background-color 0.3s ease;
 }

--- a/css/themes/dark-theme.css
+++ b/css/themes/dark-theme.css
@@ -4,7 +4,6 @@ body[data-theme="dark"] {
     --secondary-color: var(--secondary-color-dark);
     --bg-color: var(--bg-dark);
     --text-color: #ffffff; /* Explicitly set to white */
-    --card-bg: var(--card-bg-dark);
     --header-bg: var(--header-bg-dark);
     --footer-bg: rgba(18, 18, 18, 0.7);
     --border-color: var(--border-dark);
@@ -36,7 +35,6 @@ body[data-theme="dark"] .portfolio-content p {
 
 /* Ensure skill cards have a dark background and white text */
 body[data-theme="dark"] .skill-card {
-    background-color: var(--card-bg-dark);
     color: #ffffff;
 }
 

--- a/css/themes/light-theme.css
+++ b/css/themes/light-theme.css
@@ -4,7 +4,6 @@ body[data-theme="light"] {
     --secondary-color: var(--secondary-color-light);
     --bg-color: var(--bg-light);
     --text-color: #111111; /* Dark text for light theme */
-    --card-bg: var(--card-bg-light);
     --header-bg: var(--header-bg-light);
     --footer-bg: rgba(255, 255, 255, 0.5);
     --border-color: var(--border-light);
@@ -20,6 +19,5 @@ body[data-theme="light"] {
 
 /* Ensure skill cards are readable in light theme */
 body[data-theme="light"] .skill-card {
-    background-color: var(--card-bg-light);
     color: #111111;
 }


### PR DESCRIPTION
## Summary
- use a single translucent `--card-bg` value
- remove card color overrides from theme files
- apply blur effect to card, skill-card and form controls

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870bf0990548324b1794d8c8bcf4747