### PR TITLE
Make header appear as floating notch

### DIFF
--- a/css/components/header.css
+++ b/css/components/header.css
@@ -3,12 +3,12 @@
     background-color: transparent;
     box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
     position: fixed;
-    top: 15px;
+    top: 40px; /* detach from the very top */
     left: 50%;
     transform: translateX(-50%);
-    width: max-content;
-    padding: 0.5rem 1.5rem;
-    border-radius: 20px;
+    width: 80%;
+    padding: 0.75rem 1.5rem;
+    border-radius: 50px; /* pill shape */
     z-index: 1000;
     transition: all 0.3s ease;
     backdrop-filter: blur(15px);
@@ -49,7 +49,7 @@
     background: var(--holo-gradient-1);
     opacity: 0.15;
     z-index: -1;
-    border-radius: 20px;
+    border-radius: 50px;
 }
 
 /* Theme Toggle Styles */
@@ -135,6 +135,6 @@ input:checked + .theme-toggle:after {
 @media (max-width: 768px) {
     .site-header {
         width: 90%;
-        top: 10px;
+        top: 20px;
     }
 }


### PR DESCRIPTION
## Summary
- restyle header to float away from the top
- round header corners for pill look

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870c1af3b2c8324ad2c471e1ac879a7