### PR TITLE
Responsive header pill

### DIFF
--- a/css/components/header.css
+++ b/css/components/header.css
@@ -6,9 +6,9 @@
     bottom: 40px;
     left: 50%;
     transform: translateX(-50%);
-    width: 25%; 
+    width: clamp(200px, 25vw, 420px);
     padding: 0.75rem 1.5rem;
-    border-radius: 50px; 
+    border-radius: 50px;
     z-index: 1000;
     transition: all 0.3s ease;
     backdrop-filter: blur(15px);
@@ -136,9 +136,15 @@ input:checked + .theme-toggle:after {
     color: #f5f5dc !important;
 }
 
+@media (max-width: 992px) {
+    .site-header {
+        width: clamp(180px, 35vw, 360px);
+    }
+}
+
 @media (max-width: 768px) {
     .site-header {
-        width: 45%;
+        width: clamp(160px, 55vw, 300px);
         bottom: 20px;
     }
 }


### PR DESCRIPTION
## Summary
- make the pill-shaped header adapt to different screen sizes using `clamp`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870d56eba8083248cb843665f99da4b