### PR TITLE
Improve responsive navbar dock

### DIFF
--- a/css/components/header.css
+++ b/css/components/header.css
@@ -120,6 +120,7 @@ input:checked + .theme-toggle:after {
     color: #f5f5dc;
     margin-right: 0;
     font-size: 1.2rem;
+    transition: font-size 0.3s ease;
 }
 
 .nav-text {
@@ -146,5 +147,16 @@ input:checked + .theme-toggle:after {
     .site-header {
         width: clamp(160px, 55vw, 300px);
         bottom: 20px;
+    }
+}
+
+@media (max-width: 576px) {
+    .site-header {
+        width: clamp(140px, 80vw, 260px);
+        bottom: 10px;
+        padding: 0.5rem 1rem;
+    }
+    .nav-item i {
+        font-size: 1rem;
     }
 }


### PR DESCRIPTION
## Summary
- adjust icon size transitions in the navbar
- scale the bottom dock and icon size for very small screens

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6870d850df9c83249d61c3023c7f9b90