### PR TITLE
Fix navbar layout

### DIFF
--- a/css/components/header.css
+++ b/css/components/header.css
@@ -24,6 +24,14 @@
     transition: color 0.3s ease;
 }
 
+.navbar-nav {
+    margin-left: 0 !important;
+    width: 100%;
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+}
+
 .nav-link {
     font-weight: 500;
     color: #000;
@@ -50,8 +58,7 @@
     left: 0;
     right: 0;
     bottom: 0;
-    background: var(--holo-gradient-1);
-    opacity: 0.15;
+    background-color: #f5f5dc;
     z-index: -1;
     border-radius: 50px;
 }


### PR DESCRIPTION
## Summary
- remove glossy gradient overlay from navigation bar
- center icons by spacing nav items evenly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870e0c0b170832495a035033f1f5725