### PR TITLE
Improved theme toggle with Material UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -439,6 +439,9 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/react/17.0.2/umd/react.development.js" crossorigin></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/17.0.2/umd/react-dom.development.js" crossorigin></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.23.2/babel.min.js" crossorigin></script>
+    <script src="https://unpkg.com/@emotion/react@11.11.1/dist/emotion-react.umd.min.js" crossorigin></script>
+    <script src="https://unpkg.com/@emotion/styled@11.11.0/dist/emotion-styled.umd.min.js" crossorigin></script>
+    <script src="https://unpkg.com/@mui/material@5.15.8/umd/material-ui.development.js" crossorigin></script>
     <script type="text/babel" src="js/components/react-theme-toggle.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/feather-icons/dist/feather.min.js" defer></script>
 </body>

--- a/js/components/react-theme-toggle.js
+++ b/js/components/react-theme-toggle.js
@@ -1,4 +1,5 @@
 const { useState, useEffect } = React;
+const { Switch } = MaterialUI;
 
 function ThemeToggle() {
   const getPreferredTheme = () => {
@@ -62,12 +63,11 @@ function ThemeToggle() {
   }, [theme]);
 
   return (
-    React.createElement('button', {
-      onClick: toggleTheme,
-      className: `react-theme-toggle ${theme}`,
-      'aria-label': `Activate ${theme === 'light' ? 'dark' : 'light'} mode`,
-      'aria-pressed': theme === 'dark'
-    }, React.createElement('span', { className: 'icon icon-animate' }))
+    React.createElement(Switch, {
+      checked: theme === 'dark',
+      onChange: toggleTheme,
+      inputProps: { 'aria-label': 'Theme toggle' }
+    })
   );
 }
 


### PR DESCRIPTION
## Summary
- add Material UI and emotion scripts
- use Material UI `Switch` component for the theme toggle

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870fe82431c8324abc817c2ac416c6d