### PR TITLE
Fix fallback for visitor counter

### DIFF
--- a/js/components/visit-counter.js
+++ b/js/components/visit-counter.js
@@ -9,7 +9,10 @@ function VisitCounter() {
     fetch(`https://api.countapi.xyz/hit/${namespace}/${key}`)
       .then(res => res.json())
       .then(data => setCount(data.value))
-      .catch(err => console.error('View count error', err));
+      .catch(err => {
+        console.error('View count error', err);
+        setCount(0); // fallback to zero on failure
+      });
   }, []);
 
   const renderDigits = () => {


### PR DESCRIPTION
## Summary
- avoid infinite loading state when visitor counter fetch fails

## Testing
- `curl -I https://api.countapi.xyz/hit/starmanodyssey.com/portfolio` *(fails: DNS resolution failure)*

------
https://chatgpt.com/codex/tasks/task_e_6871161059688324a7cc03a5ac2253df