### PR TITLE
Fix visit counter to use MongoDB API

### DIFF
--- a/js/components/visit-counter.js
+++ b/js/components/visit-counter.js
@@ -4,14 +4,20 @@ function VisitCounter() {
   const [count, setCount] = useState(null);
 
   useEffect(() => {
-    const namespace = 'starmanodyssey.com';
-    const key = 'portfolio';
-    fetch(`https://api.countapi.xyz/hit/${namespace}/${key}`)
-      .then(res => res.json())
-      .then(data => setCount(data.value))
+    // First register the visit on the backend
+    fetch('/api/view', { method: 'POST' })
       .catch(err => {
-        console.error('View count error', err);
-        setCount(0); // fallback to zero on failure
+        console.error('View increment error', err);
+      })
+      .finally(() => {
+        // Then retrieve the current count from MongoDB
+        fetch('/api/count')
+          .then(res => res.json())
+          .then(data => setCount(data.count))
+          .catch(err => {
+            console.error('View count error', err);
+            setCount(0); // fallback to zero on failure
+          });
       });
   }, []);
 


### PR DESCRIPTION
## Summary
- use API endpoints on our Node server for counting visits

## Testing
- `npm install` in `server`
- `npm test` in `server` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6871180b72348324a26be985760060cb