### PR TITLE
Change all white color references to beige

### DIFF
--- a/css/components/contact.css
+++ b/css/components/contact.css
@@ -11,7 +11,7 @@
     transition: all 0.3s ease;
     position: relative;
     overflow: hidden;
-    border: 1px solid rgba(255, 255, 255, 0.1);
+    border: 1px solid rgba(245, 245, 220, 0.1);
 }
 
 /* Apply glossy effect to contact cards */
@@ -55,7 +55,7 @@
     height: 40px;
     line-height: 40px;
     text-align: center;
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: rgba(245, 245, 220, 0.1);
     color: var(--text-color);
     border-radius: 50%;
     margin-right: 10px;
@@ -65,19 +65,19 @@
 .social-links a:hover {
     background-color: var(--secondary-color);
     transform: translateY(-5px);
-    color: #fff;
+    color: beige;
 }
 
 /* Form styling */
 .form-control {
-    background-color: rgba(255, 255, 255, 0.05);
+    background-color: rgba(245, 245, 220, 0.05);
     border: 1px solid var(--border-color);
     color: var(--text-color);
     transition: all 0.3s ease;
 }
 
 .form-control:focus {
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: rgba(245, 245, 220, 0.1);
     border-color: var(--secondary-color);
     box-shadow: 0 0 0 0.25rem rgba(var(--secondary-color), 0.25);
     color: var(--text-color);

--- a/css/components/footer.css
+++ b/css/components/footer.css
@@ -25,7 +25,7 @@
 .footer p,
 .footer a,
 .footer .text-white {
-    color: var(--text-color) !important;
+    color: beige !important;
     position: relative;
     z-index: 1;
     transition: color 0.3s ease;

--- a/css/components/header.css
+++ b/css/components/header.css
@@ -119,7 +119,7 @@
 }
 
 .react-theme-toggle.dark .icon {
-    background: #ffffff;
+    background: #f5f5dc;
     box-shadow: inset -8px -8px 0 0 #111111;
 }
 

--- a/css/components/hero.css
+++ b/css/components/hero.css
@@ -43,7 +43,7 @@
     background-size: cover;
     background-position: center;
     border-radius: 0.5rem;
-    color: white;
+    color: beige;
     display: flex;
     flex-direction: column;
     justify-content: flex-end;

--- a/css/components/portfolio.css
+++ b/css/components/portfolio.css
@@ -68,7 +68,7 @@
 }
 
 .portfolio-content {
-    background-color: rgba(255, 255, 255, 0.05);
+    background-color: rgba(245, 245, 220, 0.05);
     backdrop-filter: blur(5px);
     -webkit-backdrop-filter: blur(5px);
 }
@@ -83,7 +83,7 @@
     backdrop-filter: blur(10px);
     -webkit-backdrop-filter: blur(10px);
     z-index: -1;
-    border: 1px solid rgba(255, 255, 255, 0.1);
+    border: 1px solid rgba(245, 245, 220, 0.1);
     border-radius: 0.5rem;
 }
 
@@ -123,7 +123,7 @@
     background-color: var(--card-bg);
     backdrop-filter: blur(8px);
     -webkit-backdrop-filter: blur(8px);
-    border: 1px solid rgba(255, 255, 255, 0.1);
+    border: 1px solid rgba(245, 245, 220, 0.1);
     transition: transform 0.3s ease, box-shadow 0.3s ease;
     border-radius: 0.5rem;
     overflow: hidden;

--- a/css/components/skills.css
+++ b/css/components/skills.css
@@ -14,7 +14,7 @@
     background-color: var(--card-bg);
     backdrop-filter: blur(8px);
     -webkit-backdrop-filter: blur(8px);
-    border: 1px solid rgba(255, 255, 255, 0.1);
+    border: 1px solid rgba(245, 245, 220, 0.1);
     border-radius: 0.5rem;
     padding: 1.5rem;
     height: 100%;

--- a/css/hero-overlay.css
+++ b/css/hero-overlay.css
@@ -67,7 +67,7 @@
     z-index: 2;
     font-weight: 700;
     font-size: 2rem;
-    color: white;
+    color: beige;
     text-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
 }
 
@@ -76,7 +76,7 @@
     top: 2rem;
     right: 2rem;
     font-size: 0.8rem;
-    color: rgba(255, 255, 255, 0.8);
+    color: rgba(245, 245, 220, 0.8);
     text-transform: uppercase;
     letter-spacing: 1px;
     text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
@@ -89,7 +89,7 @@
     font-size: 0.875rem;
     text-transform: uppercase;
     letter-spacing: 1px;
-    color: rgba(255, 255, 255, 0.9);
+    color: rgba(245, 245, 220, 0.9);
     z-index: 2;
     text-shadow: 0 1px 3px rgba(0, 0, 0, 0.7);
 }
@@ -112,7 +112,7 @@
     font-size: 5rem;
     font-weight: 800;
     line-height: 0.9;
-    color: white;
+    color: beige;
     text-transform: uppercase;
     max-width: 600px;
     text-shadow: 0 2px 10px rgba(0, 0, 0, 0.7);
@@ -126,7 +126,7 @@
 }
 
 .hero-cta button {
-    background: white;
+    background: beige;
     color: black;
     border: none;
     padding: 0.7rem 2rem;
@@ -137,7 +137,7 @@
 }
 
 .hero-cta button:hover {
-    background: rgba(255, 255, 255, 0.9);
+    background: rgba(245, 245, 220, 0.9);
     transform: translateY(-3px);
     box-shadow: 0 6px 15px rgba(0, 0, 0, 0.4);
 }

--- a/css/main.css
+++ b/css/main.css
@@ -6,21 +6,21 @@
     --primary-color-light: #2c3e50;
     --secondary-color-light: #3498db;
     --bg-light: #f8f9fa;
-    --text-light: #ffffff; /* unused now */
-    --header-bg-light: rgba(255, 255, 255, 0.85);
-    --footer-bg-light: #ffffff;
-    --border-light: rgb(255, 255, 255);
+    --text-light: #f5f5dc; /* unused now */
+    --header-bg-light: rgba(245, 245, 220, 0.85);
+    --footer-bg-light: #f5f5dc;
+    --border-light: rgb(245, 245, 220);
 
     /* Multi Color Theme Colors */
     --primary-color-dark: #bb86fc;
     --secondary-color-dark: #03dac6;
     --bg-dark: #121212;
-    --text-dark: #ffffff; /* unused now */
+    --text-dark: #f5f5dc; /* unused now */
     --header-bg-dark: rgba(30, 30, 30, 0.85);
     --footer-bg-dark: rgba(18, 18, 18, 0.9);
-    --border-dark: rgba(255, 255, 255, 0.1);
+    --border-dark: rgba(245, 245, 220, 0.1);
     --text-color: #111111;
-    --card-bg: rgba(255, 255, 255, 0.15);
+    --card-bg: rgba(245, 245, 220, 0.15);
 }
 
 body, input, textarea, button, select, optgroup {

--- a/css/themes/dark-theme.css
+++ b/css/themes/dark-theme.css
@@ -3,7 +3,7 @@ body[data-theme="dark"] {
     --primary-color: var(--primary-color-dark);
     --secondary-color: var(--secondary-color-dark);
     --bg-color: var(--bg-dark);
-    --text-color: #ffffff; /* Explicitly set to white */
+    --text-color: #f5f5dc; /* Explicitly set to beige */
     --header-bg: var(--header-bg-dark);
     --footer-bg: rgba(18, 18, 18, 0.7);
     --border-color: var(--border-dark);
@@ -30,12 +30,12 @@ body[data-theme="dark"] .card-title,
 body[data-theme="dark"] label,
 body[data-theme="dark"] .portfolio-title,
 body[data-theme="dark"] .portfolio-content p {
-    color: #ffffff !important;
+    color: #f5f5dc !important;
 }
 
 /* Ensure skill cards have a dark background and white text */
 body[data-theme="dark"] .skill-card {
-    color: #ffffff;
+    color: #f5f5dc;
 }
 
 /* Animation for dark theme transition */

--- a/css/themes/light-theme.css
+++ b/css/themes/light-theme.css
@@ -5,12 +5,12 @@ body[data-theme="light"] {
     --bg-color: var(--bg-light);
     --text-color: #111111; /* Dark text for light theme */
     --header-bg: var(--header-bg-light);
-    --footer-bg: rgba(255, 255, 255, 0.5);
+    --footer-bg: rgba(245, 245, 220, 0.5);
     --border-color: var(--border-light);
 
     /* Holographic Gradients - Light Theme */
-    --holo-gradient-1: linear-gradient(45deg, rgba(255, 255, 255, 0.9), rgba(143, 213, 255, 0.8), rgba(177, 156, 217, 0.7), rgba(249, 184, 253, 0.8), rgba(255, 255, 255, 0.9));
-    --holo-gradient-2: linear-gradient(135deg, rgba(252, 252, 252, 0.9), rgba(160, 216, 239, 0.8), rgba(185, 223, 237, 0.7), rgba(200, 240, 245, 0.8), rgba(255, 255, 255, 0.9));
+    --holo-gradient-1: linear-gradient(45deg, rgba(245, 245, 220, 0.9), rgba(143, 213, 255, 0.8), rgba(177, 156, 217, 0.7), rgba(249, 184, 253, 0.8), rgba(245, 245, 220, 0.9));
+    --holo-gradient-2: linear-gradient(135deg, rgba(245, 245, 220, 0.9), rgba(160, 216, 239, 0.8), rgba(185, 223, 237, 0.7), rgba(200, 240, 245, 0.8), rgba(245, 245, 220, 0.9));
 
     /* Dynamic background variables */
     --bg-opacity: 0.04;

--- a/js/components/theme-switcher.js
+++ b/js/components/theme-switcher.js
@@ -130,14 +130,14 @@ document.addEventListener('DOMContentLoaded', function() {
         applyTheme('dark');
         createHolographicGradient(Date.now() / 20000, false);
     
-        // Text color white for dark theme
-        document.documentElement.style.setProperty('--text-color', '#ffffff');
-        document.body.style.color = '#ffffff';
+        // Text color beige for dark theme
+        document.documentElement.style.setProperty('--text-color', '#f5f5dc');
+        document.body.style.color = '#f5f5dc';
     
         // Also update inputs and textareas text color
         const formInputs = document.querySelectorAll('input, textarea, select, button');
         formInputs.forEach(input => {
-            input.style.color = '#ffffff';
+            input.style.color = '#f5f5dc';
             input.style.backgroundColor = '#222'; // dark background for inputs
             input.style.borderColor = '#555';
         });
@@ -155,7 +155,7 @@ document.addEventListener('DOMContentLoaded', function() {
         const formInputs = document.querySelectorAll('input, textarea, select, button');
         formInputs.forEach(input => {
             input.style.color = '#111111';
-            input.style.backgroundColor = '#fff'; // light background for inputs
+            input.style.backgroundColor = '#f5f5dc'; // light background for inputs
             input.style.borderColor = '#ccc';
         });
     }


### PR DESCRIPTION
## Summary
- update dark theme text color to beige
- switch hero overlay and hero components to beige accents
- override footer text color with beige
- update input styles and theme switcher to use beige
- change light theme gradients and colors to beige
- adjust portfolio, skills, and contact components to use beige highlights

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687129d4a8e88324a789ba574f0ffc2f