### PR TITLE
Fix MongoDB connection string handling

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -22,8 +22,13 @@ app.use(limiter);
 // The password is URI encoded to ensure special characters are handled correctly.
 // Example: plain-text password "p@ssw0rd'9'!" becomes "p%40ssw0rd%279%27%21".
 const encodedPassword = encodeURIComponent(process.env.DB_PASSWORD || 'Assassin10');
-const mongoUri = process.env.MONGO_URI ||
+let mongoUri = process.env.MONGO_URI ||
     `mongodb+srv://forprogrammingonly01:${encodedPassword}@cluster0.ojfinsc.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0`;
+
+// Replace placeholder password if the user copied the example connection string
+if (mongoUri.includes('<password>')) {
+    mongoUri = mongoUri.replace('<password>', encodedPassword);
+}
 
 mongoose.connect(mongoUri, { useNewUrlParser: true, useUnifiedTopology: true })
     .then(() => console.log('Connected to MongoDB'))


### PR DESCRIPTION
## Summary
- allow replacing `<password>` placeholder when using a `.env` connection string

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6871443cd56c8324a37c43476d1e2fd7