### PR TITLE
Fix visitor counter fallback

### DIFF
--- a/js/components/visit-counter.js
+++ b/js/components/visit-counter.js
@@ -6,23 +6,34 @@ function VisitCounter() {
   useEffect(() => {
     async function fetchCount() {
       try {
-        // Log this visit and fetch the current count from the backend
+        // Try the backend first
         await fetch('/api/view', { method: 'POST' });
         const res = await fetch('/api/count');
-        if (!res.ok) throw new Error('Network response was not ok');
+        if (!res.ok) throw new Error('Backend response was not ok');
         const data = await res.json();
         setCount(data.count);
         localStorage.setItem('visitCount', data.count);
       } catch (err) {
-        console.error('View count error', err);
-        const stored = localStorage.getItem('visitCount');
-        if (stored !== null) {
-          const parsed = parseInt(stored, 10) || 0;
-          const newCount = parsed + 1;
-          localStorage.setItem('visitCount', newCount);
-          setCount(newCount);
-        } else {
-          setCount(0);
+        console.error('Backend view count error, falling back to CountAPI', err);
+        try {
+          const namespace = 'starmanodyssey.com';
+          const key = 'portfolio';
+          const res = await fetch(`https://api.countapi.xyz/hit/${namespace}/${key}`);
+          if (!res.ok) throw new Error('CountAPI response was not ok');
+          const data = await res.json();
+          setCount(data.value);
+          localStorage.setItem('visitCount', data.value);
+        } catch (err2) {
+          console.error('CountAPI error', err2);
+          const stored = localStorage.getItem('visitCount');
+          if (stored !== null) {
+            const parsed = parseInt(stored, 10) || 0;
+            const newCount = parsed + 1;
+            localStorage.setItem('visitCount', newCount);
+            setCount(newCount);
+          } else {
+            setCount(0);
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- handle server errors in VisitCounter
- fall back to countapi.xyz when backend isn't available

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6871622814a88324991b67c48927c3e6