### PR TITLE
Fix beige text for light theme

### DIFF
--- a/css/themes/light-theme.css
+++ b/css/themes/light-theme.css
@@ -19,7 +19,7 @@ body[data-theme="light"] {
 
 /* Ensure skill cards are readable in light theme */
 body[data-theme="light"] .skill-card {
-    color: #000;
+    color: #f5f5dc;
 }
 
 /* Override text color for specific sections */
@@ -27,5 +27,5 @@ body[data-theme="light"] #skills,
 body[data-theme="light"] #skills *,
 body[data-theme="light"] #experience,
 body[data-theme="light"] #experience * {
-    color: #000 !important;
+    color: #f5f5dc !important;
 }


### PR DESCRIPTION
## Summary
- adjust light theme CSS so text remains beige when theme is toggled off

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68724e82e8048324baaaf64e5268b1a9