### PR TITLE
Fix dark theme text color

### DIFF
--- a/css/themes/dark-theme.css
+++ b/css/themes/dark-theme.css
@@ -17,7 +17,7 @@ body[data-theme="dark"] {
     --overlay-opacity: 0.03;
 
     /* Default text color for dark theme */
-    color: #f5f5dc;
+    color: var(--text-color);
 }
 
 /* Additional text color overrides for dark theme */
@@ -46,7 +46,7 @@ body[data-theme="dark"] #skills,
 body[data-theme="dark"] #skills *,
 body[data-theme="dark"] #experience,
 body[data-theme="dark"] #experience * {
-    color: #000 !important;
+    color: #f5f5dc !important;
 }
 
 /* Animation for dark theme transition */

--- a/css/themes/light-theme.css
+++ b/css/themes/light-theme.css
@@ -15,6 +15,9 @@ body[data-theme="light"] {
     /* Dynamic background variables */
     --bg-opacity: 0.04;
     --overlay-opacity: 0.02;
+
+    /* Default text color for light theme */
+    color: var(--text-color);
 }
 
 /* Ensure skill cards are readable in light theme */


### PR DESCRIPTION
## Summary
- ensure beige text is applied in dark theme to skills and experience sections
- use beige text color variable across both themes

## Testing
- `npm test` *(fails: Error: ENOENT: no such file or directory, open '/workspace/portfolio/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68725038fb988324b192f91df43be947