### PR TITLE
Fix React toggle initialization

### DIFF
--- a/js/react/main.jsx
+++ b/js/react/main.jsx
@@ -1,10 +1,17 @@
-document.addEventListener('DOMContentLoaded', () => {
+function initReactWidgets() {
   const themeEl = document.getElementById('react-theme-toggle');
   if (themeEl && window.ThemeToggle) {
     ReactDOM.render(React.createElement(window.ThemeToggle), themeEl);
   }
+
   const counterEl = document.getElementById('visit-counter');
   if (counterEl && window.VisitCounter) {
     ReactDOM.render(React.createElement(window.VisitCounter), counterEl);
   }
-});
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initReactWidgets);
+} else {
+  initReactWidgets();
+}


### PR DESCRIPTION
## Summary
- make React widgets bootstrap even if DOMContentLoaded has fired

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6875431eb1508324b917db31f4c430be