### PR TITLE
Fix mobile navbar icon overflow

### DIFF
--- a/css/components/header.css
+++ b/css/components/header.css
@@ -6,8 +6,9 @@
     bottom: 40px;
     left: 50%;
     transform: translateX(-50%);
-    width: clamp(200px, 25vw, 420px);
-    padding: 0.75rem 1.5rem;
+    width: fit-content;
+    max-width: 90vw;
+    padding: 0.5rem 1rem;
     border-radius: 50px;
     z-index: 1000;
     transition: all 0.3s ease;
@@ -40,8 +41,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 48px;
-    height: 48px;
+    width: clamp(32px, 9vw, 44px);
+    height: clamp(32px, 9vw, 44px);
 }
 
 .nav-link.active {
@@ -102,8 +103,8 @@
 /* React Theme Toggle */
 .react-theme-toggle {
     cursor: pointer;
-    width: 40px;
-    height: 40px;
+    width: clamp(26px, 9vw, 38px);
+    height: clamp(26px, 9vw, 38px);
     background: transparent;
     border: none;
     display: flex;
@@ -168,7 +169,7 @@
 .nav-item i {
     color: #00224D;
     margin-right: 0;
-    font-size: 1.2rem;
+    font-size: clamp(0.8rem, 3vw, 1.1rem);
     line-height: 1;
     transition: font-size 0.3s ease;
 }
@@ -187,63 +188,16 @@
     color: #00224D !important;
 }
 
-@media (max-width: 992px) {
-    .site-header {
-        width: clamp(180px, 35vw, 360px);
-    }
-}
-
 @media (max-width: 768px) {
     .site-header {
-        width: clamp(160px, 55vw, 300px);
         bottom: 20px;
     }
 }
 
 @media (max-width: 576px) {
     .site-header {
-        width: clamp(140px, 80vw, 260px);
         bottom: 10px;
         padding: 0.5rem 1rem;
-    }
-    .nav-item i {
-        font-size: 1rem;
-    }
-    .nav-link {
-        width: 40px;
-        height: 40px;
-    }
-    .react-theme-toggle {
-        width: 34px;
-        height: 34px;
-    }
-}
-
-@media (max-width: 480px) {
-    .nav-item i {
-        font-size: 0.9rem;
-    }
-    .nav-link {
-        width: 36px;
-        height: 36px;
-    }
-    .react-theme-toggle {
-        width: 30px;
-        height: 30px;
-    }
-}
-
-@media (max-width: 360px) {
-    .nav-item i {
-        font-size: 0.8rem;
-    }
-    .nav-link {
-        width: 32px;
-        height: 32px;
-    }
-    .react-theme-toggle {
-        width: 26px;
-        height: 26px;
     }
 }
 


### PR DESCRIPTION
## Summary
- adjust header pill to size dynamically with `fit-content`
- scale nav icons and theme toggle using `clamp`
- simplify responsive rules

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687684b469ec8324a5e4bf208db083e7