### PR TITLE
Fix navbar hover underline color

### DIFF
--- a/css/components/header.css
+++ b/css/components/header.css
@@ -77,6 +77,11 @@
     background-color: #000;
 }
 
+/* Ensure underline stays black on hover */
+.nav-link:hover::after {
+    background-color: #000;
+}
+
 /* Glossy header effect */
 .site-header::before {
     content: "";


### PR DESCRIPTION
## Summary
- ensure navbar underline stays black on hover

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6876a7889b2883249f3adc91140b5004