### PR TITLE
Ensure dark mode uses pure black backgrounds

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -14,10 +14,10 @@
     /* Multi Color Theme Colors */
     --primary-color-dark: #bb86fc;
     --secondary-color-dark: #03dac6;
-    --bg-dark: #121212;
+    --bg-dark: #000000;
     --text-dark: #f5f5dc; /* unused now */
-    --header-bg-dark: rgba(30, 30, 30, 0.85);
-    --footer-bg-dark: rgba(18, 18, 18, 0.9);
+    --header-bg-dark: rgba(0, 0, 0, 0.85);
+    --footer-bg-dark: rgba(0, 0, 0, 0.9);
     --border-dark: rgba(245, 245, 220, 0.1);
     --text-color: #f5f5dc;
     --card-bg: rgba(245, 245, 220, 0.15);

--- a/css/themes/dark-theme.css
+++ b/css/themes/dark-theme.css
@@ -5,7 +5,7 @@ body[data-theme="dark"] {
     --bg-color: var(--bg-dark);
     --text-color: #f5f5dc; /* Explicitly set to beige */
     --header-bg: var(--header-bg-dark);
-    --footer-bg: rgba(18, 18, 18, 0.7);
+    --footer-bg: rgba(0, 0, 0, 0.7);
     --border-color: var(--border-dark);
 
     /* Holographic Gradients - Dark Theme */

--- a/js/components/theme-switcher.js
+++ b/js/components/theme-switcher.js
@@ -92,7 +92,7 @@ document.addEventListener('DOMContentLoaded', function() {
     function createHolographicGradient(time, useColor) {
         if (!useColor) {
             // Plain dark background when color mode is off
-            document.body.style.background = '#111';
+            document.body.style.background = '#000';
             document.documentElement.style.setProperty('--overlay-opacity', '0');
             document.documentElement.style.setProperty('--holo-gradient-1', 'none');
             document.documentElement.style.setProperty('--holo-gradient-2', 'none');


### PR DESCRIPTION
## Summary
- use pure black background variables in `css/main.css`
- update dark theme footer background
- make background animation use pure black in `theme-switcher.js`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6876a8e1c01883248518ee80b7c0ff42