### PR TITLE
Set beige navigation pill and black nav icons

### DIFF
--- a/css/components/header.css
+++ b/css/components/header.css
@@ -189,7 +189,7 @@
 
 /* Icon + text visibility */
 .nav-item i {
-    color: #00224D;
+    color: #000 !important;
     margin-right: 0;
     font-size: clamp(0.7rem, 2.5vw, 1rem);
     line-height: 1;
@@ -207,7 +207,7 @@
     }
 }
 .nav-link .fa-circle-user {
-    color: #00224D !important;
+    color: #000 !important;
 }
 
 @media (max-width: 768px) {

--- a/css/main.css
+++ b/css/main.css
@@ -16,7 +16,7 @@
     --secondary-color-dark: #03dac6;
     --bg-dark: #000000;
     --text-dark: #f5f5dc; /* unused now */
-    --header-bg-dark: rgba(0, 0, 0, 0.85);
+    --header-bg-dark: rgba(245, 245, 220, 0.85);
     --footer-bg-dark: rgba(0, 0, 0, 0.9);
     --border-dark: rgba(245, 245, 220, 0.1);
     --text-color: #f5f5dc;


### PR DESCRIPTION
## Summary
- ensure the navigation pill background uses beige in all themes
- keep navigation icons black regardless of theme toggle

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877517b0f108324bd5f8425fe44955a