### PR TITLE
Fix dark mode toggle appearance

### DIFF
--- a/css/components/header.css
+++ b/css/components/header.css
@@ -210,6 +210,15 @@
     color: #000 !important;
 }
 
+/* Container for React dark mode switch */
+#dark-mode-toggle {
+    width: clamp(28px, 7vw, 36px);
+    height: clamp(28px, 7vw, 36px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
 @media (max-width: 768px) {
     .site-header {
         bottom: 20px;

--- a/js/react/main.mjs
+++ b/js/react/main.mjs
@@ -70,10 +70,11 @@ function ThemeToggle() {
   };
 
   return React.createElement(DarkModeSwitch, {
-    style: { marginBottom: '2rem' },
     checked: isDarkMode,
     onChange: toggleDarkMode,
-    size: 24
+    size: 24,
+    moonColor: '#000',
+    sunColor: '#000'
   });
 }
 


### PR DESCRIPTION
## Summary
- keep dark mode toggle centered in nav pill
- set moon icon color to black

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687761e3ec28832487bc1d87ea1d02aa