### PR TITLE
Adjust colors for skills/experience

### DIFF
--- a/css/components/experience.css
+++ b/css/components/experience.css
@@ -49,5 +49,5 @@
 .timeline-item span {
     display: block;
     font-size: 0.875rem;
-    color: #aaa;
+    color: #2cff05;
 }

--- a/css/themes/dark-theme.css
+++ b/css/themes/dark-theme.css
@@ -38,7 +38,7 @@ body[data-theme="dark"] .portfolio-content p {
 
 /* Ensure skill cards have a dark background and white text */
 body[data-theme="dark"] .skill-card {
-    color: #f5f5dc;
+    color: #2cff05;
 }
 
 /* Override text color for specific sections */
@@ -46,7 +46,7 @@ body[data-theme="dark"] #skills,
 body[data-theme="dark"] #skills *,
 body[data-theme="dark"] #experience,
 body[data-theme="dark"] #experience * {
-    color: #f5f5dc !important;
+    color: #2cff05 !important;
 }
 
 /* Animation for dark theme transition */

--- a/css/themes/light-theme.css
+++ b/css/themes/light-theme.css
@@ -22,7 +22,7 @@ body[data-theme="light"] {
 
 /* Ensure skill cards are readable in light theme */
 body[data-theme="light"] .skill-card {
-    color: #f5f5dc;
+    color: #2cff05;
 }
 
 /* Override text color for specific sections */
@@ -30,5 +30,5 @@ body[data-theme="light"] #skills,
 body[data-theme="light"] #skills *,
 body[data-theme="light"] #experience,
 body[data-theme="light"] #experience * {
-    color: #f5f5dc !important;
+    color: #2cff05 !important;
 }


### PR DESCRIPTION
## Summary
- colorize the Technological Skills section with neon green
- colorize the Experience section with neon green

## Testing
- `npm test --prefix server` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6877df0f342083248914376f096ab61d