### PR TITLE
Update skills and experience styles

### DIFF
--- a/css/components/experience.css
+++ b/css/components/experience.css
@@ -2,7 +2,8 @@
     padding: 5rem 0;
     position: relative;
     overflow: hidden;
-    background-color: #00224D;
+    background-color: #39ff14;
+    color: #000;
 }
 
 .experience-section .section-title {
@@ -49,5 +50,5 @@
 .timeline-item span {
     display: block;
     font-size: 0.875rem;
-    color: #2cff05;
+    color: #000;
 }

--- a/css/components/skills.css
+++ b/css/components/skills.css
@@ -2,7 +2,8 @@
     padding: 5rem 0;
     position: relative;
     overflow: hidden;
-    background-color: #00224D;
+    background-color: #39ff14;
+    color: #000;
 }
 
 .skills-section .section-title {

--- a/css/themes/dark-theme.css
+++ b/css/themes/dark-theme.css
@@ -38,7 +38,7 @@ body[data-theme="dark"] .portfolio-content p {
 
 /* Ensure skill cards have a dark background and white text */
 body[data-theme="dark"] .skill-card {
-    color: #2cff05;
+    color: #000;
 }
 
 /* Override text color for specific sections */
@@ -46,7 +46,7 @@ body[data-theme="dark"] #skills,
 body[data-theme="dark"] #skills *,
 body[data-theme="dark"] #experience,
 body[data-theme="dark"] #experience * {
-    color: #2cff05 !important;
+    color: #000 !important;
 }
 
 /* Animation for dark theme transition */

--- a/css/themes/light-theme.css
+++ b/css/themes/light-theme.css
@@ -22,7 +22,7 @@ body[data-theme="light"] {
 
 /* Ensure skill cards are readable in light theme */
 body[data-theme="light"] .skill-card {
-    color: #2cff05;
+    color: #000;
 }
 
 /* Override text color for specific sections */
@@ -30,5 +30,5 @@ body[data-theme="light"] #skills,
 body[data-theme="light"] #skills *,
 body[data-theme="light"] #experience,
 body[data-theme="light"] #experience * {
-    color: #2cff05 !important;
+    color: #000 !important;
 }


### PR DESCRIPTION
## Summary
- update skills section color scheme
- update experience section color scheme
- override theme colors for these sections in both themes

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6877f6dcad2c8324b36651ee5a1a4c8e