### PR TITLE
Simplify theme to black/beige/red palette

### DIFF
--- a/css/components/about.css
+++ b/css/components/about.css
@@ -28,5 +28,5 @@
     width: 80%;
     height: auto;
     border-radius: 0.5rem;
-    box-shadow: 0 5px 15px rgba(0, 34, 77, 0.1);
+    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
 }

--- a/css/components/contact.css
+++ b/css/components/contact.css
@@ -7,7 +7,7 @@
     background-color: transparent;
     border-radius: 0.5rem;
     padding: 2rem;
-    box-shadow: 0 5px 15px rgba(0, 34, 77, 0.1);
+    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
     transition: all 0.3s ease;
     position: relative;
     overflow: hidden;

--- a/css/components/experience.css
+++ b/css/components/experience.css
@@ -2,8 +2,8 @@
     padding: 5rem 0;
     position: relative;
     overflow: hidden;
-    background-color: #39ff14;
-    color: #000;
+    background-color: var(--alt-bg);
+    color: var(--alt-text);
 }
 
 .experience-section .section-title {
@@ -50,5 +50,5 @@
 .timeline-item span {
     display: block;
     font-size: 0.875rem;
-    color: #000;
+    color: var(--alt-text);
 }

--- a/css/components/header.css
+++ b/css/components/header.css
@@ -1,7 +1,7 @@
 /* Header Styles */
 .site-header {
     background-color: var(--header-bg);
-    box-shadow: 0 2px 10px rgba(0, 34, 77, 0.1);
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
     position: fixed;
     bottom: 40px;
     left: 50%;
@@ -184,7 +184,7 @@
 /* Scrolled state */
 .site-header.navbar-scrolled {
     background-color: var(--header-bg);
-    box-shadow: 0 2px 10px rgba(0, 34, 77, 0.2);
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
 }
 
 /* Icon + text visibility */

--- a/css/components/hero.css
+++ b/css/components/hero.css
@@ -16,7 +16,7 @@
     left: 0;
     right: 0;
     bottom: 0;
-    background: rgba(0, 34, 77, 0.5);
+    background: rgba(0, 0, 0, 0.5);
     z-index: 1;
 }
 

--- a/css/components/portfolio.css
+++ b/css/components/portfolio.css
@@ -29,7 +29,7 @@
     margin-bottom: 2rem;
     border-radius: 0.5rem;
     overflow: hidden;
-    box-shadow: 0 5px 15px rgba(0, 34, 77, 0.1);
+    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
     transition: transform 0.3s ease, box-shadow 0.3s ease;
     background-color: transparent;
     position: relative;
@@ -37,7 +37,7 @@
 
 .portfolio-item:hover {
     transform: translateY(-10px);
-    box-shadow: 0 15px 30px rgba(0, 34, 77, 0.15);
+    box-shadow: 0 15px 30px rgba(0, 0, 0, 0.15);
 }
 
 /* Holographic effect for portfolio items */
@@ -127,12 +127,12 @@
     transition: transform 0.3s ease, box-shadow 0.3s ease;
     border-radius: 0.5rem;
     overflow: hidden;
-    box-shadow: 0 5px 15px rgba(0, 34, 77, 0.1);
+    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
 }
 
 .card:hover {
     transform: translateY(-5px);
-    box-shadow: 0 15px 30px rgba(0, 34, 77, 0.15);
+    box-shadow: 0 15px 30px rgba(0, 0, 0, 0.15);
 }
 
 .card-img-top {

--- a/css/components/skills.css
+++ b/css/components/skills.css
@@ -2,8 +2,8 @@
     padding: 5rem 0;
     position: relative;
     overflow: hidden;
-    background-color: #39ff14;
-    color: #000;
+    background-color: var(--alt-bg);
+    color: var(--alt-text);
 }
 
 .skills-section .section-title {
@@ -19,5 +19,5 @@
     border-radius: 0.5rem;
     padding: 1.5rem;
     height: 100%;
-    box-shadow: 0 5px 15px rgba(0, 34, 77, 0.1);
+    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
 }

--- a/css/main.css
+++ b/css/main.css
@@ -2,24 +2,17 @@
 @import url('https://fonts.googleapis.com/css2?family=Anonymous+Pro:wght@400;700&family=Fira+Code:wght@400;700&family=Source+Code+Pro:wght@400;700&display=swap');
 
 :root {
-    /* Real Dark Theme Colors */
-    --primary-color-light: #2c3e50;
-    --secondary-color-light: #3498db;
-    --bg-light: #f8f9fa;
-    --text-light: #f5f5dc; /* unused now */
-    --header-bg-light: rgba(245, 245, 220, 0.85);
-    --footer-bg-light: #f5f5dc;
-    --border-light: rgb(245, 245, 220);
+    --black: #000;
+    --beige: #f5f5dc;
+    --red: #ee3224;
 
-    /* Multi Color Theme Colors */
-    --primary-color-dark: #bb86fc;
-    --secondary-color-dark: #03dac6;
-    --bg-dark: #000000;
-    --text-dark: #f5f5dc; /* unused now */
-    --header-bg-dark: rgba(245, 245, 220, 0.85);
-    --footer-bg-dark: rgba(0, 0, 0, 0.9);
-    --border-dark: rgba(245, 245, 220, 0.1);
-    --text-color: #f5f5dc;
+    --primary-color: var(--beige);
+    --secondary-color: var(--red);
+    --bg-color: var(--black);
+    --text-color: var(--beige);
+    --header-bg: rgba(0, 0, 0, 0.85);
+    --footer-bg: var(--black);
+    --border-color: rgba(245, 245, 220, 0.3);
     --card-bg: rgba(245, 245, 220, 0.15);
 }
 

--- a/css/themes/dark-theme.css
+++ b/css/themes/dark-theme.css
@@ -1,22 +1,20 @@
 /* Dark Theme Specific Styles */
 body[data-theme="dark"] {
-    --primary-color: var(--primary-color-dark);
-    --secondary-color: var(--secondary-color-dark);
-    --bg-color: var(--bg-dark);
-    --text-color: #f5f5dc; /* Explicitly set to beige */
-    --header-bg: var(--header-bg-dark);
-    --footer-bg: rgba(0, 0, 0, 0.7);
-    --border-color: var(--border-dark);
+    --bg-color: var(--black);
+    --text-color: var(--beige);
+    --primary-color: var(--beige);
+    --secondary-color: var(--red);
+    --header-bg: rgba(0, 0, 0, 0.85);
+    --footer-bg: rgba(0, 0, 0, 0.9);
+    --border-color: rgba(245, 245, 220, 0.1);
+    --card-bg: rgba(245, 245, 220, 0.15);
+    --alt-bg: var(--beige);
+    --alt-text: var(--black);
 
-    /* Holographic Gradients - Dark Theme */
-    --holo-gradient-1: linear-gradient(45deg, rgba(38, 38, 38, 0.9), rgba(61, 95, 115, 0.8), rgba(77, 68, 95, 0.7), rgba(109, 80, 110, 0.8), rgba(38, 38, 38, 0.9));
-    --holo-gradient-2: linear-gradient(135deg, rgba(31, 31, 31, 0.9), rgba(56, 89, 107, 0.8), rgba(73, 94, 101, 0.7), rgba(78, 112, 117, 0.8), rgba(31, 31, 31, 0.9));
-
-    /* Dynamic background variables */
-    --bg-opacity: 0.05;
-    --overlay-opacity: 0.03;
-
-    /* Default text color for dark theme */
+    --holo-gradient-1: none;
+    --holo-gradient-2: none;
+    --bg-opacity: 0;
+    --overlay-opacity: 0;
     color: var(--text-color);
 }
 
@@ -46,16 +44,5 @@ body[data-theme="dark"] #skills,
 body[data-theme="dark"] #skills *,
 body[data-theme="dark"] #experience,
 body[data-theme="dark"] #experience * {
-    color: #000 !important;
-}
-
-/* Animation for dark theme transition */
-@keyframes lightToDark {
-    0% { opacity: 0.8; }
-    50% { opacity: 0.4; }
-    100% { opacity: 0.8; }
-}
-
-.dark-theme-active::after {
-    animation: lightToDark 1s forwards;
+    color: var(--black) !important;
 }

--- a/css/themes/light-theme.css
+++ b/css/themes/light-theme.css
@@ -1,28 +1,26 @@
 /* Light Theme Specific Styles */
 body[data-theme="light"] {
-    --primary-color: var(--primary-color-light);
-    --secondary-color: var(--secondary-color-light);
-    --bg-color: var(--bg-light);
-    --text-color: #f5f5dc; /* Beige text for consistency */
-    --header-bg: var(--header-bg-light);
+    --bg-color: var(--beige);
+    --text-color: var(--black);
+    --primary-color: var(--black);
+    --secondary-color: var(--red);
+    --header-bg: rgba(245, 245, 220, 0.85);
     --footer-bg: rgba(245, 245, 220, 0.5);
-    --border-color: var(--border-light);
+    --border-color: rgba(0, 0, 0, 0.1);
+    --card-bg: rgba(0, 0, 0, 0.05);
+    --alt-bg: var(--black);
+    --alt-text: var(--beige);
 
-    /* Holographic Gradients - Light Theme */
-    --holo-gradient-1: linear-gradient(45deg, rgba(245, 245, 220, 0.9), rgba(143, 213, 255, 0.8), rgba(177, 156, 217, 0.7), rgba(249, 184, 253, 0.8), rgba(245, 245, 220, 0.9));
-    --holo-gradient-2: linear-gradient(135deg, rgba(245, 245, 220, 0.9), rgba(160, 216, 239, 0.8), rgba(185, 223, 237, 0.7), rgba(200, 240, 245, 0.8), rgba(245, 245, 220, 0.9));
-
-    /* Dynamic background variables */
-    --bg-opacity: 0.04;
-    --overlay-opacity: 0.02;
-
-    /* Default text color for light theme */
+    --holo-gradient-1: none;
+    --holo-gradient-2: none;
+    --bg-opacity: 0;
+    --overlay-opacity: 0;
     color: var(--text-color);
 }
 
 /* Ensure skill cards are readable in light theme */
 body[data-theme="light"] .skill-card {
-    color: #000;
+    color: var(--black);
 }
 
 /* Override text color for specific sections */
@@ -30,5 +28,5 @@ body[data-theme="light"] #skills,
 body[data-theme="light"] #skills *,
 body[data-theme="light"] #experience,
 body[data-theme="light"] #experience * {
-    color: #000 !important;
+    color: var(--black) !important;
 }

--- a/js/components/theme-switcher.js
+++ b/js/components/theme-switcher.js
@@ -1,193 +1,32 @@
-// Dynamic theme switcher with multiple-color holographic gradients
-document.addEventListener('DOMContentLoaded', function() {
-    console.log('Theme switcher initialized');
-    const themeToggleBtn = document.getElementById('theme-toggle-btn');
-    const iconEl = themeToggleBtn ? themeToggleBtn.querySelector('.icon') : null;
+// Simple theme switcher using black, beige and red palette
+// Toggles between light and dark themes and exposes global functions
 
-    // Animation state
-    let animationRunning = false;
-    let animationFrameId = null;
+document.addEventListener('DOMContentLoaded', () => {
+    const btn = document.getElementById('theme-toggle-btn');
 
-    // Initialize dynamic background effects
-    startBackgroundAnimation();
+    function setTheme(theme) {
+        document.documentElement.setAttribute('data-theme', theme);
+        document.body.setAttribute('data-theme', theme);
+        localStorage.setItem('theme', theme);
+        if (btn) {
+            btn.classList.toggle('light', theme === 'light');
+            btn.classList.toggle('dark', theme === 'dark');
+        }
+    }
 
-    // Toggle theme when the button is clicked
-    if (themeToggleBtn) {
-        themeToggleBtn.addEventListener('click', function() {
-            console.log('Theme toggle button clicked');
+    function applyDarkTheme() { setTheme('dark'); }
+    function applyLightTheme() { setTheme('light'); }
 
-            // Stop current animation
-            stopBackgroundAnimation();
+    const saved = localStorage.getItem('theme') || 'dark';
+    setTheme(saved);
 
-            const isLight = document.body.getAttribute('data-theme') === 'light';
-
-            if (isLight) {
-                applyDarkTheme();
-                localStorage.setItem('theme', 'dark');
-            } else {
-                applyLightTheme();
-                localStorage.setItem('theme', 'light');
-            }
-
-            updateButton();
-
-            if (iconEl) {
-                iconEl.classList.add('icon-animate');
-                iconEl.addEventListener('animationend', () => {
-                    iconEl.classList.remove('icon-animate');
-                }, { once: true });
-            }
-
-            // Restart animation
-            startBackgroundAnimation();
+    if (btn) {
+        btn.addEventListener('click', () => {
+            const current = document.body.getAttribute('data-theme');
+            setTheme(current === 'light' ? 'dark' : 'light');
         });
     }
 
-    // Start the background animation
-    function startBackgroundAnimation() {
-        if (animationRunning) return;
-
-        console.log('Starting background animation');
-        animationRunning = true;
-
-        // Start animation loop
-        function animate() {
-            const currentTheme = document.body.getAttribute('data-theme') || 'light';
-            const now = Date.now();
-
-            // Instead of using a single base hue, we'll use multiple distinct hues
-            // that shift at different rates for a more interesting effect
-            const time = now / 20000; // Slower cycle for more gradual changes
-
-            if (currentTheme === 'dark') {
-                createHolographicGradient(time, false);
-            } else {
-                createHolographicGradient(time, true);
-            }
-
-            // Continue animation loop if still running
-            if (animationRunning) {
-                animationFrameId = requestAnimationFrame(animate);
-            }
-        }
-
-        // Start the animation loop
-        animationFrameId = requestAnimationFrame(animate);
-    }
-
-    // Stop the background animation
-    function stopBackgroundAnimation() {
-        console.log('Stopping background animation');
-        animationRunning = false;
-
-        if (animationFrameId) {
-            cancelAnimationFrame(animationFrameId);
-            animationFrameId = null;
-        }
-    }
-
-    // Create a rich holographic gradient with multiple distinct colors
-    function createHolographicGradient(time, useColor) {
-        if (!useColor) {
-            // Plain dark background when color mode is off
-            document.body.style.background = '#000';
-            document.documentElement.style.setProperty('--overlay-opacity', '0');
-            document.documentElement.style.setProperty('--holo-gradient-1', 'none');
-            document.documentElement.style.setProperty('--holo-gradient-2', 'none');
-            return;
-        }
-
-        // DARK THEME: Holographic gradient as before
-        const angle = (Date.now() / 150) % 360;
-
-        const hue1 = (time * 100) % 360;
-        const hue2 = ((time * 120) + 120) % 360;
-        const hue3 = ((time * 80) + 240) % 360;
-        const hue4 = ((time * 140) + 180) % 360;
-
-        const colors = [
-            `hsla(${hue1}, 70%, 15%, 0.95)`,
-            `hsla(${hue2}, 65%, 18%, 0.85)`,
-            `hsla(${hue3}, 60%, 12%, 0.8)`,
-            `hsla(${hue4}, 70%, 10%, 0.9)`
-        ];
-
-        const pulseValue = (Math.sin(time * 10) * 0.015) + 0.04;
-        document.documentElement.style.setProperty('--overlay-opacity', pulseValue.toFixed(3));
-
-        const gradient = `linear-gradient(${angle}deg, ${colors.join(', ')})`;
-        document.body.style.background = gradient;
-
-        const colorValues = colors.map(color => color.replace('hsla', 'rgba').replace(/%/g, ''));
-        const holoGradient = `linear-gradient(${(angle + 45) % 360}deg, ${colorValues[0]}, ${colorValues[1]}, ${colorValues[2]}, ${colorValues[3]})`;
-        document.documentElement.style.setProperty('--holo-gradient-1', holoGradient);
-        document.documentElement.style.setProperty('--holo-gradient-2', `linear-gradient(${(angle + 135) % 360}deg, ${colorValues[3]}, ${colorValues[0]}, ${colorValues[1]}, ${colorValues[2]})`);
-    }
-
-    function applyDarkTheme() {
-        applyTheme('dark');
-        createHolographicGradient(Date.now() / 20000, false);
-    
-        // Text color beige for dark theme
-        document.documentElement.style.setProperty('--text-color', '#f5f5dc');
-        document.body.style.color = '#f5f5dc';
-    
-        // Also update inputs and textareas text color
-        const formInputs = document.querySelectorAll('input, textarea, select, button');
-        formInputs.forEach(input => {
-            input.style.color = '#f5f5dc';
-            input.style.backgroundColor = '#222'; // dark background for inputs
-            input.style.borderColor = '#555';
-        });
-    }
-    
-    function applyLightTheme() {
-        applyTheme('light');
-        createHolographicGradient(Date.now() / 20000, true);
-    
-        // Text color beige for light theme
-        document.documentElement.style.setProperty('--text-color', '#f5f5dc');
-        document.body.style.color = '#f5f5dc';
-    
-        // Also update inputs and textareas text color
-        const formInputs = document.querySelectorAll('input, textarea, select, button');
-        formInputs.forEach(input => {
-            input.style.color = '#f5f5dc';
-            input.style.backgroundColor = '#222'; // dark background for inputs
-            input.style.borderColor = '#555';
-        });
-    }
-    
-
-    // Helper to set data-theme attribute on body
-    function applyTheme(themeName) {
-        document.body.setAttribute('data-theme', themeName);
-    }
-
-    function updateButton() {
-        if (!themeToggleBtn) return;
-        const current = document.body.getAttribute('data-theme');
-        if (current === 'light') {
-            themeToggleBtn.classList.remove('dark');
-            themeToggleBtn.classList.add('light');
-        } else {
-            themeToggleBtn.classList.remove('light');
-            themeToggleBtn.classList.add('dark');
-        }
-    }
-
-    // On page load: apply saved theme or default to dark
-    const savedTheme = localStorage.getItem('theme') || 'dark';
-    if (savedTheme === 'light') {
-        applyLightTheme();
-    } else {
-        applyDarkTheme();
-    }
-    updateButton();
-
-    // Expose theme functions globally for React component
     window.applyDarkTheme = applyDarkTheme;
     window.applyLightTheme = applyLightTheme;
-    window.startBackgroundAnimation = startBackgroundAnimation;
-    window.stopBackgroundAnimation = stopBackgroundAnimation;
 });


### PR DESCRIPTION
## Summary
- define black, beige and red colors globally
- rework light/dark theme styles
- alternate section backgrounds
- drop holographic effects and implement a minimal theme switcher

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687813b88fbc8324a094a9a46520bea8