### PR TITLE
Fix nav icon visibility in dark mode

### DIFF
--- a/css/components/header.css
+++ b/css/components/header.css
@@ -189,7 +189,7 @@
 
 /* Icon + text visibility */
 .nav-item i {
-    color: #000 !important;
+    color: var(--icon-color) !important;
     margin-right: 0;
     font-size: clamp(0.7rem, 2.5vw, 1rem);
     line-height: 1;
@@ -207,7 +207,7 @@
     }
 }
 .nav-link .fa-circle-user {
-    color: #000 !important;
+    color: var(--icon-color) !important;
 }
 
 /* Container for React dark mode switch */

--- a/css/main.css
+++ b/css/main.css
@@ -14,6 +14,7 @@
     --footer-bg: var(--black);
     --border-color: rgba(245, 245, 220, 0.3);
     --card-bg: rgba(245, 245, 220, 0.15);
+    --icon-color: var(--black);
 }
 
 body, input, textarea, button, select, optgroup {

--- a/css/themes/dark-theme.css
+++ b/css/themes/dark-theme.css
@@ -10,6 +10,7 @@ body[data-theme="dark"] {
     --card-bg: rgba(245, 245, 220, 0.15);
     --alt-bg: var(--beige);
     --alt-text: var(--black);
+    --icon-color: #fff;
 
     --holo-gradient-1: none;
     --holo-gradient-2: none;

--- a/css/themes/light-theme.css
+++ b/css/themes/light-theme.css
@@ -10,6 +10,7 @@ body[data-theme="light"] {
     --card-bg: rgba(0, 0, 0, 0.05);
     --alt-bg: var(--black);
     --alt-text: var(--beige);
+    --icon-color: #000;
 
     --holo-gradient-1: none;
     --holo-gradient-2: none;


### PR DESCRIPTION
## Summary
- add `--icon-color` CSS variable
- use icon color for nav icons
- configure `--icon-color` for light and dark themes

## Testing
- `npm test --prefix server` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68781723f56083249ce8adc8d501b4a4