### PR TITLE
Fix dark mode icon color

### DIFF
--- a/css/components/header.css
+++ b/css/components/header.css
@@ -193,7 +193,11 @@
     margin-right: 0;
     font-size: clamp(0.7rem, 2.5vw, 1rem);
     line-height: 1;
-    transition: font-size 0.3s ease;
+    transition: color 0.3s ease, font-size 0.3s ease;
+}
+
+body[data-theme="dark"] .nav-item i {
+    color: #fff !important;
 }
 
 .nav-text {


### PR DESCRIPTION
## Summary
- tweak header CSS to ensure nav icons are white in dark mode

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687818aad3a88324bfa9a7cdc02823d1