### PR TITLE
Apply Gensler red for dark mode nav pills

### DIFF
--- a/css/components/header.css
+++ b/css/components/header.css
@@ -46,6 +46,11 @@
     position: relative;
 }
 
+body[data-theme="dark"] .nav-link {
+    background-color: var(--nav-pill-bg);
+    border-radius: 50%;
+}
+
 /* Animated underline for hover/active state */
 .nav-link::after {
     content: '';

--- a/css/main.css
+++ b/css/main.css
@@ -5,6 +5,7 @@
     --black: #000;
     --beige: #f5f5dc;
     --red: #ee3224;
+    --gensler-red: #da291c;
 
     --primary-color: var(--beige);
     --secondary-color: var(--red);
@@ -15,6 +16,7 @@
     --border-color: rgba(245, 245, 220, 0.3);
     --card-bg: rgba(245, 245, 220, 0.15);
     --icon-color: var(--black);
+    --nav-pill-bg: transparent;
 }
 
 body, input, textarea, button, select, optgroup {

--- a/css/themes/dark-theme.css
+++ b/css/themes/dark-theme.css
@@ -11,6 +11,7 @@ body[data-theme="dark"] {
     --alt-bg: var(--beige);
     --alt-text: var(--black);
     --icon-color: #fff;
+    --nav-pill-bg: var(--gensler-red);
 
     --holo-gradient-1: none;
     --holo-gradient-2: none;


### PR DESCRIPTION
## Summary
- add `--gensler-red` variable
- style dark theme nav pills using Gensler red
- default nav pill background transparent in light theme

## Testing
- `npm test --prefix server` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687874ac12e88324858cd472ab55a677