### PR TITLE
Make nav pills beige with black icons

### DIFF
--- a/css/components/header.css
+++ b/css/components/header.css
@@ -44,9 +44,6 @@
     width: clamp(28px, 7vw, 36px);
     height: clamp(28px, 7vw, 36px);
     position: relative;
-}
-
-body[data-theme="dark"] .nav-link {
     background-color: var(--nav-pill-bg);
     border-radius: 50%;
 }
@@ -201,9 +198,6 @@ body[data-theme="dark"] .nav-link {
     transition: color 0.3s ease, font-size 0.3s ease;
 }
 
-body[data-theme="dark"] .nav-item i {
-    color: #fff !important;
-}
 
 .nav-text {
     display: none;

--- a/css/main.css
+++ b/css/main.css
@@ -16,7 +16,7 @@
     --border-color: rgba(245, 245, 220, 0.3);
     --card-bg: rgba(245, 245, 220, 0.15);
     --icon-color: var(--black);
-    --nav-pill-bg: transparent;
+    --nav-pill-bg: var(--beige);
 }
 
 body, input, textarea, button, select, optgroup {

--- a/css/themes/dark-theme.css
+++ b/css/themes/dark-theme.css
@@ -10,8 +10,8 @@ body[data-theme="dark"] {
     --card-bg: rgba(245, 245, 220, 0.15);
     --alt-bg: var(--beige);
     --alt-text: var(--black);
-    --icon-color: #fff;
-    --nav-pill-bg: var(--gensler-red);
+    --icon-color: #000;
+    --nav-pill-bg: var(--beige);
 
     --holo-gradient-1: none;
     --holo-gradient-2: none;


### PR DESCRIPTION
## Summary
- always render nav pills with a beige background
- keep nav icons black in all themes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687888a011c48324998b3bc4b24c05fc