### PR TITLE
Maintain beige nav pill across themes

### DIFF
--- a/js/react/main.mjs
+++ b/js/react/main.mjs
@@ -73,8 +73,8 @@ function ThemeToggle() {
     checked: isDarkMode,
     onChange: toggleDarkMode,
     size: 24,
-    moonColor: '#000',
-    sunColor: '#000'
+    moonColor: '#f5f5dc',
+    sunColor: '#f5f5dc'
   });
 }
 


### PR DESCRIPTION
## Summary
- revert navigation underline color back to black
- keep theme switcher icons beige so nav pill never turns dark

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68794bab874c8324a0d9c5653ac732b2