### PR TITLE
Fix dark mode switch icon colors

### DIFF
--- a/css/components/header.css
+++ b/css/components/header.css
@@ -118,7 +118,7 @@
 }
 
 .theme-toggle.dark {
-    color: #fff;
+    color: var(--beige);
 }
 
 .theme-toggle .icon {
@@ -145,8 +145,8 @@
 }
 
 .theme-toggle.dark .icon {
-    /* White circle for the moon */
-    background: #fff;
+    /* Beige circle for the moon */
+    background: var(--beige);
     /* Create crescent by masking with a solid color */
     box-shadow: inset -8px -8px 0 0 #000;
 }

--- a/js/react/main.mjs
+++ b/js/react/main.mjs
@@ -69,12 +69,14 @@ function ThemeToggle() {
     }
   };
 
+  const iconColor = isDarkMode ? '#f5f5dc' : '#000';
+
   return React.createElement(DarkModeSwitch, {
     checked: isDarkMode,
     onChange: toggleDarkMode,
     size: 24,
-    moonColor: '#f5f5dc',
-    sunColor: '#f5f5dc'
+    moonColor: iconColor,
+    sunColor: iconColor
   });
 }
 


### PR DESCRIPTION
## Summary
- show beige moon icon in dark theme via CSS
- make React dark mode switch icon colors follow the active theme

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68796088cfec8324b7e3c1e63a3597b3