### PR TITLE
Fix dark mode toggle initial state

### DIFF
--- a/js/react/main.mjs
+++ b/js/react/main.mjs
@@ -58,7 +58,13 @@ function VisitCounter() {
 }
 
 function ThemeToggle() {
-  const [isDarkMode, setDarkMode] = useState(document.body.getAttribute('data-theme') === 'dark');
+  const [isDarkMode, setDarkMode] = useState(() => {
+    const stored = localStorage.getItem('theme');
+    if (stored) {
+      return stored === 'dark';
+    }
+    return true; // default to dark theme
+  });
 
   const toggleDarkMode = (checked) => {
     setDarkMode(checked);


### PR DESCRIPTION
## Summary
- ensure theme toggle reads user's theme preference from localStorage

## Testing
- `npm test --prefix server` *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_687962b6bfac8324b72abd8a0173acdf