### PR TITLE
Add neon red gradient to navigation pills

### DIFF
--- a/css/components/header.css
+++ b/css/components/header.css
@@ -44,9 +44,24 @@
     width: clamp(28px, 7vw, 36px);
     height: clamp(28px, 7vw, 36px);
     position: relative;
-    /* Keep navigation pills beige regardless of theme */
-    background-color: var(--beige) !important;
+    border: 2px solid transparent;
     border-radius: 50%;
+    background:
+        var(--beige) padding-box,
+        linear-gradient(120deg, var(--gensler-red), #ff0040, var(--gensler-red))
+        border-box;
+    background-size: 200% 200%;
+    background-clip: padding-box, border-box;
+    animation: nav-border-flow 4s linear infinite;
+}
+
+@keyframes nav-border-flow {
+    from {
+        background-position: 0% 50%;
+    }
+    to {
+        background-position: 100% 50%;
+    }
 }
 
 /* Animated underline for hover/active state */


### PR DESCRIPTION
## Summary
- style navigation pills with a neon Gensler red gradient border
- animate gradient flow around the pills

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6879651693d48324828039fddb95b985