### PR TITLE
Fix light theme text contrast

### DIFF
--- a/css/themes/light-theme.css
+++ b/css/themes/light-theme.css
@@ -30,5 +30,5 @@ body[data-theme="light"] #skills,
 body[data-theme="light"] #skills *,
 body[data-theme="light"] #experience,
 body[data-theme="light"] #experience * {
-    color: var(--black) !important;
+    color: var(--beige) !important;
 }


### PR DESCRIPTION
## Summary
- correct text color for the skills and experience sections when in the light theme so that beige text appears on the black background

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688748763a7883249f5e633001567dcb