### PR TITLE
Change text colors per section

### DIFF
--- a/css/components/contact.css
+++ b/css/components/contact.css
@@ -56,7 +56,7 @@
     line-height: 40px;
     text-align: center;
     background-color: rgba(245, 245, 220, 0.1);
-    color: var(--text-color);
+    color: inherit;
     border-radius: 50%;
     margin-right: 10px;
     transition: all 0.3s ease;
@@ -72,7 +72,7 @@
 .form-control {
     background-color: rgba(245, 245, 220, 0.05);
     border: 1px solid var(--border-color);
-    color: var(--text-color);
+    color: inherit;
     transition: all 0.3s ease;
 }
 
@@ -80,9 +80,9 @@
     background-color: rgba(245, 245, 220, 0.1);
     border-color: var(--secondary-color);
     box-shadow: 0 0 0 0.25rem rgba(var(--secondary-color), 0.25);
-    color: var(--text-color);
+    color: inherit;
 }
 
 .form-label {
-    color: var(--text-color);
+    color: inherit;
 }

--- a/css/components/experience.css
+++ b/css/components/experience.css
@@ -3,7 +3,6 @@
     position: relative;
     overflow: hidden;
     background-color: var(--alt-bg);
-    color: var(--alt-text);
 }
 
 .experience-section .section-title {
@@ -50,5 +49,5 @@
 .timeline-item span {
     display: block;
     font-size: 0.875rem;
-    color: var(--alt-text);
+    color: inherit;
 }

--- a/css/components/portfolio.css
+++ b/css/components/portfolio.css
@@ -15,7 +15,7 @@
     padding: 0.5rem 1.5rem;
     margin: 0 0.5rem;
     font-weight: 500;
-    color: var(--text-color);
+    color: inherit;
     border-bottom: 2px solid transparent;
     transition: all 0.3s ease;
 }
@@ -145,7 +145,7 @@
 }
 
 .text-muted {
-    color: var(--text-color) !important;
+    color: inherit !important;
     opacity: 0.7;
 }
 

--- a/css/components/skills.css
+++ b/css/components/skills.css
@@ -3,7 +3,6 @@
     position: relative;
     overflow: hidden;
     background-color: var(--alt-bg);
-    color: var(--alt-text);
 }
 
 .skills-section .section-title {

--- a/css/main.css
+++ b/css/main.css
@@ -10,7 +10,6 @@
     --primary-color: var(--beige);
     --secondary-color: var(--red);
     --bg-color: var(--black);
-    --text-color: var(--beige);
     --header-bg: rgba(0, 0, 0, 0.85);
     --footer-bg: var(--black);
     --border-color: rgba(245, 245, 220, 0.3);
@@ -33,7 +32,6 @@ body, input, textarea, button, select, optgroup {
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    color: var(--text-color); /* Theme-based text color */
     background-color: var(--bg-color);
     transition: color 0.3s ease;
 }
@@ -47,7 +45,6 @@ h1, h2, h3, h4, h5, h6 {
             monospace;
     font-weight: 700;
     letter-spacing: -0.5px;
-    color: var(--text-color); /* Theme-based text color */
     transition: color 0.3s ease;
 }
 
@@ -63,7 +60,6 @@ pre, code, kbd, samp {
     background-color: rgba(0,0,0,0.05);
     border-radius: 4px;
     padding: 0.2em 0.4em;
-    color: var(--text-color); /* Theme-based text color */
     transition: color 0.3s ease;
 }
 
@@ -87,19 +83,16 @@ pre {
     padding: 0.1em 0.3em;
     border-radius: 3px;
     margin: 0 0.2em;
-    color: var(--text-color); /* Theme-based text color */
     transition: color 0.3s ease;
 }
 
 /* Add styles for regular text */
 p, span, div, a:not(.btn), label, li {
-    color: var(--text-color); /* Theme-based text color */
     transition: color 0.3s ease;
 }
 
 /* Add styles for form elements */
 .form-control, .form-control:focus {
-    color: var(--text-color); /* Theme-based text color */
     background-color: var(--card-bg);
     backdrop-filter: blur(8px);
     -webkit-backdrop-filter: blur(8px);

--- a/css/themes/dark-theme.css
+++ b/css/themes/dark-theme.css
@@ -1,7 +1,6 @@
 /* Dark Theme Specific Styles */
 body[data-theme="dark"] {
     --bg-color: var(--black);
-    --text-color: var(--beige);
     --primary-color: var(--beige);
     --secondary-color: var(--red);
     --header-bg: rgba(0, 0, 0, 0.85);
@@ -17,7 +16,7 @@ body[data-theme="dark"] {
     --holo-gradient-2: none;
     --bg-opacity: 0;
     --overlay-opacity: 0;
-    color: var(--text-color);
+    color: var(--beige);
 }
 
 /* Additional text color overrides for dark theme */
@@ -47,4 +46,18 @@ body[data-theme="dark"] #skills *,
 body[data-theme="dark"] #experience,
 body[data-theme="dark"] #experience * {
     color: var(--black) !important;
+}
+
+/* Section text colors */
+body[data-theme="dark"] .about-section,
+body[data-theme="dark"] .hero,
+body[data-theme="dark"] .portfolio-section,
+body[data-theme="dark"] .contact-section,
+body[data-theme="dark"] .footer {
+    color: var(--beige);
+}
+
+body[data-theme="dark"] .skills-section,
+body[data-theme="dark"] .experience-section {
+    color: var(--black);
 }

--- a/css/themes/light-theme.css
+++ b/css/themes/light-theme.css
@@ -1,7 +1,6 @@
 /* Light Theme Specific Styles */
 body[data-theme="light"] {
     --bg-color: var(--beige);
-    --text-color: var(--black);
     --primary-color: var(--black);
     --secondary-color: var(--red);
     --header-bg: rgba(245, 245, 220, 0.85);
@@ -17,7 +16,7 @@ body[data-theme="light"] {
     --holo-gradient-2: none;
     --bg-opacity: 0;
     --overlay-opacity: 0;
-    color: var(--text-color);
+    color: var(--black);
 }
 
 /* Ensure skill cards are readable in light theme */
@@ -31,4 +30,18 @@ body[data-theme="light"] #skills *,
 body[data-theme="light"] #experience,
 body[data-theme="light"] #experience * {
     color: var(--beige) !important;
+}
+
+/* Section text colors */
+body[data-theme="light"] .about-section,
+body[data-theme="light"] .hero,
+body[data-theme="light"] .portfolio-section,
+body[data-theme="light"] .contact-section,
+body[data-theme="light"] .footer {
+    color: var(--black);
+}
+
+body[data-theme="light"] .skills-section,
+body[data-theme="light"] .experience-section {
+    color: var(--beige);
 }


### PR DESCRIPTION
## Summary
- drop global `--text-color` variable
- use theme css to set section text colors
- update contact and portfolio styles to inherit text color
- simplify skills and experience css

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6887512be3488324b0b9f2d05d73ef8c