### PR TITLE
Fix loader color to match theme

### DIFF
--- a/css/components/loader.css
+++ b/css/components/loader.css
@@ -19,8 +19,8 @@
     line-height: 1.4;
     font-weight: bold;
     background:
-        linear-gradient(#000 0 0) left,
-        linear-gradient(#000 0 0) right;
+        linear-gradient(var(--loader-color) 0 0) left,
+        linear-gradient(var(--loader-color) 0 0) right;
     background-repeat: no-repeat;
     border-right: 5px solid #0000;
     border-left: 5px solid #0000;
@@ -41,10 +41,10 @@
     width: 22px;
     height: 60px;
     background:
-        linear-gradient(90deg,#000 4px,#0000 0 calc(100% - 4px),#000 0) bottom/22px 20px,
+        linear-gradient(90deg,var(--loader-color) 4px,#0000 0 calc(100% - 4px),var(--loader-color) 0) bottom/22px 20px,
         linear-gradient(90deg,red 4px,#0000 0 calc(100% - 4px),red 0) bottom 10px left 0/22px 6px,
-        linear-gradient(#000 0 0) bottom 3px left 0/22px 8px,
-        linear-gradient(#000 0 0) bottom 0 left 50%/8px 16px;
+        linear-gradient(var(--loader-color) 0 0) bottom 3px left 0/22px 8px,
+        linear-gradient(var(--loader-color) 0 0) bottom 0 left 50%/8px 16px;
     background-repeat: no-repeat;
     animation: l9-1 2s infinite;
 }

--- a/css/main.css
+++ b/css/main.css
@@ -16,6 +16,7 @@
     --card-bg: rgba(245, 245, 220, 0.15);
     --icon-color: var(--black);
     --nav-pill-bg: var(--beige);
+    --loader-color: var(--beige);
 }
 
 body, input, textarea, button, select, optgroup {

--- a/css/themes/dark-theme.css
+++ b/css/themes/dark-theme.css
@@ -12,6 +12,8 @@ body[data-theme="dark"] {
     --icon-color: #000;
     --nav-pill-bg: var(--beige);
 
+    --loader-color: var(--beige);
+
     --holo-gradient-1: none;
     --holo-gradient-2: none;
     --bg-opacity: 0;

--- a/css/themes/light-theme.css
+++ b/css/themes/light-theme.css
@@ -12,6 +12,8 @@ body[data-theme="light"] {
     --icon-color: #000;
     --nav-pill-bg: var(--beige);
 
+    --loader-color: var(--black);
+
     --holo-gradient-1: none;
     --holo-gradient-2: none;
     --bg-opacity: 0;

--- a/index.html
+++ b/index.html
@@ -27,6 +27,13 @@
 </head>
 
 <body>
+    <script>
+        (function() {
+            const saved = localStorage.getItem('theme') || 'dark';
+            document.documentElement.setAttribute('data-theme', saved);
+            document.body.setAttribute('data-theme', saved);
+        })();
+    </script>
 
     <div id="loading-screen">
         <div class="loader"></div>


### PR DESCRIPTION
## Summary
- ensure the loader changes color with the current theme
- define `--loader-color` CSS variable
- set loader color for light and dark themes
- update loader styles to use the variable
- initialize theme at page load to prevent flash

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688753ac2bb88324a3dc742613a3beb9