### PR TITLE
Fix screenshot URL encoding

### DIFF
--- a/js/components/project-screenshot.js
+++ b/js/components/project-screenshot.js
@@ -6,7 +6,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const url = card.dataset.url;
     const img = card.querySelector('.project-snapshot');
     if (url && img) {
-      img.src = `https://image.thum.io/get/${encodeURIComponent(url)}`;
+      // Thum.io expects the target URL directly in the path without encoding
+      img.src = `https://image.thum.io/get/${url}`;
     }
   });
 });


### PR DESCRIPTION
## Summary
- update `project-screenshot.js` to remove URL encoding when fetching thumbnails

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688757e825e48324bad9ef94c49d285f