### PR TITLE
Refresh project snapshots on reload

### DIFF
--- a/js/components/project-screenshot.js
+++ b/js/components/project-screenshot.js
@@ -7,7 +7,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const img = card.querySelector('.project-snapshot');
     if (url && img) {
       // Thum.io expects the target URL directly in the path without encoding
-      img.src = `https://image.thum.io/get/${url}`;
+      // Append a timestamp to bypass caching and refresh the snapshot on each reload
+      const cacheBust = Date.now();
+      img.src = `https://image.thum.io/get/${url}?cacheBust=${cacheBust}`;
     }
   });
 });


### PR DESCRIPTION
## Summary
- ensure screenshots request a fresh image by adding a cache-busting timestamp

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6887599c6b98832480c39528682f3e19