### PR TITLE
Update sections with cards and restore colors

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -113,3 +113,20 @@ p, span, div, a:not(.btn), label, li {
         font-size: 14px;
     }
 }
+
+/* Generic section layout for clear separation */
+.section {
+    padding: 4rem 0;
+    border-bottom: 1px solid var(--border-color);
+}
+
+/* Card wrapper for each section */
+.section-card {
+    background-color: var(--card-bg);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    border: 1px solid var(--border-color);
+    border-radius: 0.5rem;
+    padding: 2rem;
+    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
+}

--- a/index.html
+++ b/index.html
@@ -72,8 +72,8 @@
     </header>
 
     <!-- About Section -->
-    <section class="about-section" id="about">
-        <div class="container">
+    <section class="about-section section" id="about">
+        <div class="container section-card">
             <h2 class="section-title">About Me</h2>
             <div class="row align-items-center">
                 <div class="col-lg-4 mb-4 mb-lg-0">
@@ -109,8 +109,8 @@
     </section>
 
     <!-- Skills Section -->
-    <section class="skills-section" id="skills">
-        <div class="container">
+    <section class="skills-section section" id="skills">
+        <div class="container section-card">
             <h2 class="section-title">Technological Skills</h2>
             <div class="row">
                 <div class="col-md-6 col-lg-4 mb-4">
@@ -203,8 +203,8 @@
     </section>
 
     <!-- Experience Section -->
-    <section class="experience-section" id="experience">
-        <div class="container">
+    <section class="experience-section section" id="experience">
+        <div class="container section-card">
             <h2 class="section-title">Experience</h2>
             <div class="timeline">
                 <div class="timeline-item">
@@ -228,8 +228,8 @@
     </section>
 
     <!-- Hero Section -->
-    <section class="hero" id="home" style="background-image: url('images/hero-bg.jpg');">
-        <div class="container">
+    <section class="hero section" id="home" style="background-image: url('images/hero-bg.jpg');">
+        <div class="container section-card">
             <div class="hero-content">
                 <h1>Blending Technology & Architecture</h1>
                 <p>Innovative solutions at the intersection of digital technology and architectural design</p>
@@ -239,21 +239,23 @@
     </section>
 
     <!-- Featured Project -->
-    <section class="container mt-5">
-        <div class="featured-project" style="background-image: url('images/featured-project.jpg');">
-            <div class="featured-project-content">
-                <span class="badge bg-primary mb-2">Featured Project</span>
-                <h2 class="fs-1 mb-3">Modern Office Complex</h2>
-                <p class="mb-4">An award-winning commercial space that integrates smart building technology with
+    <section class="section">
+        <div class="container section-card mt-5">
+            <div class="featured-project" style="background-image: url('images/featured-project.jpg');">
+                <div class="featured-project-content">
+                    <span class="badge bg-primary mb-2">Featured Project</span>
+                    <h2 class="fs-1 mb-3">Modern Office Complex</h2>
+                    <p class="mb-4">An award-winning commercial space that integrates smart building technology with
                     sustainable architectural design.</p>
-                <a href="#" class="btn btn-light">View Project</a>
+                    <a href="#" class="btn btn-light">View Project</a>
+                </div>
             </div>
         </div>
     </section>
 
     <!-- Projects Section -->
-    <section class="portfolio-section" id="projects">
-        <div class="container">
+    <section class="portfolio-section section" id="projects">
+        <div class="container section-card">
             <h2 class="section-title">My Projects</h2>
 
             <div class="portfolio-tabs">
@@ -279,8 +281,9 @@
 
 
     <!-- Recent Blog Posts -->
-    <section class="container my-5" id="blog">
-        <h2 class="section-title">Recent Articles</h2>
+    <section class="section" id="blog">
+        <div class="container my-5 section-card">
+            <h2 class="section-title">Recent Articles</h2>
         <div class="row g-4">
             <div class="col-12 col-md-6 linkedin-embed">
                 <iframe src="https://www.linkedin.com/embed/feed/update/urn:li:activity:7291424422861643776"
@@ -303,11 +306,12 @@
             <a href="https://x.com/starman_o11/status/1849169754701086762"></a>
         </blockquote>
         <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+        </div>
     </section>
 
     <!-- Contact Section -->
-    <section class="contact-section" id="contact">
-        <div class="container">
+    <section class="contact-section section" id="contact">
+        <div class="container section-card">
             <h2 class="section-title">Get In Touch</h2>
             <div class="row">
                 <div class="col-md-6 mb-4 mb-md-0">


### PR DESCRIPTION
## Summary
- revert the minimal theme changes
- add `.section` and new `.section-card` wrappers in main CSS
- wrap content of each section with the new card container
- default theme logic points back to light/dark themes

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68875aad73f48324a80942aef096409e